### PR TITLE
update repo URL references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ GITHUB_REPO=repository_name
 
 ### Integration Points
 
-- **GitHub Repository**: [design-system-docs](https://github.com/pglevy/design-system-docs) - Source of truth for all documentation
+- **GitHub Repository**: [design-system-docs](https://github.com/appian-design/aurora) - Source of truth for all documentation
 - **AI Assistants**: Provides real-time access to design system guidance during development
 - **Development Workflow**: Enables contextual design system assistance within coding environments
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,8 +147,8 @@ design-system-server/
 ## Questions and Support
 
 - Check our [README](README.md) for setup instructions
-- Search through [existing issues](https://github.com/pglevy/design-system-server/issues)
-- Start a [discussion](https://github.com/pglevy/design-system-server/discussions) for questions
+- Search through [existing issues](https://github.com/appian-design/aurora-mcp/issues)
+- Start a [discussion](https://github.com/appian-design/aurora-mcp/discussions) for questions
 - Review the [MCP specification](https://modelcontextprotocol.io/docs) for technical details
 
 Thank you for contributing to making the Design System MCP Server better for everyone!

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -69,7 +69,7 @@ The MCP server needs API access to GitHub to fetch the design system documentati
 
 At a high level, here's what you need to do:
 
-- Fork the [design-system-docs](https://github.com/pglevy/design-system-docs) repo (*not* the design-system-server repo this file is in) to your account (i.e., `yourname/design-system-docs`)
+- Fork the [design-system-docs](https://github.com/appian-design/aurora) repo (*not* the design-system-server repo this file is in) to your account (i.e., `yourname/design-system-docs`)
 - Create a Personal Access Token (PAT) to allow API access to your forked repo
 - Copy the PAT to your local copy of the `design-system-server` repo
 
@@ -81,7 +81,7 @@ If you need access to internal documentation, you'll also need:
 - Additional environment configuration
 
 
-1. **Fork the [design-system-docs](https://github.com/pglevy/design-system-docs) repo**
+1. **Fork the [design-system-docs](https://github.com/appian-design/aurora) repo**
    - Use the Fork button at the top of repo page
      - It will be created as a private repo in your account because the parent repo is private (for now)
 
@@ -178,7 +178,7 @@ Now that the MCP server is configured, you'll want to create a separate workspac
    - Select your new working project folder
    - This gives you a clean workspace for your design system files
 
-1. **Download or copy [CLAUDE.md](https://github.com/pglevy/design-system-docs/blob/main/CLAUDE.md) from `design-system-docs`**
+1. **Download or copy [CLAUDE.md](https://github.com/appian-design/aurora/blob/main/CLAUDE.md) from `design-system-docs`**
    - Put this file in your project folder (it provides some "tips and tricks" for Q to avoid silly SAIL mistakes)
 
 1. **Understanding the workflow:**
@@ -252,7 +252,7 @@ Example queries:
 
 ## Step 9: Leave Feedback
 
-Run into a problem or have an idea for improvement? [Open an issue in `design-system-docs` using the Feedback template](https://github.com/pglevy/design-system-docs/issues/new?template=beta-feedback.md)
+Run into a problem or have an idea for improvement? [Open an issue in `design-system-docs` using the Feedback template](https://github.com/appian-design/aurora/issues/new?template=beta-feedback.md)
 
 ## Troubleshooting
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -7,7 +7,7 @@ documentation:
     public:
       enabled: true
       path: "./docs-public"
-      repo: "https://github.com/pglevy/design-system-docs.git"
+      repo: "https://github.com/appian-design/aurora.git"
       branch: "main"
       priority: 1
       auth_required: false
@@ -17,7 +17,7 @@ documentation:
     # internal:
     #   enabled: false
     #   path: "./docs-internal"
-    #   repo: "https://github.com/pglevy/design-system-docs-internal.git"
+    #   repo: "https://github.com/appian-design/aurora-internal.git"
     #   branch: "main"
     #   priority: 2
     #   auth_required: true

--- a/context/migration-session-summary.md
+++ b/context/migration-session-summary.md
@@ -24,7 +24,7 @@ Migrate the Design System MCP Server from fetching content via GitHub Gists API 
 ## Migration Requirements
 
 1. **Content Structure:** Combine guidance and code into single markdown files using frontmatter template
-2. **Repository:** Migrate to private repo `https://github.com/pglevy/design-system-docs`
+2. **Repository:** Migrate to private repo `https://github.com/appian-design/aurora`
 3. **Navigation:** Expand to full 6-category structure from `nav.md`
 4. **Authentication:** Use Personal Access Token for private repo access
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,14 +14,14 @@ documentation:
     public:
       enabled: true
       path: "./docs-public"
-      repo: "https://github.com/pglevy/design-system-docs.git"
+      repo: "https://github.com/appian-design/aurora.git"
       branch: "main"
       priority: 1
       auth_required: false
     internal:
       enabled: false
       path: "./docs-internal"
-      repo: "https://github.com/pglevy/design-system-docs-internal.git"
+      repo: "https://github.com/appian-design/aurora-internal.git"
       branch: "main"
       priority: 2
       auth_required: true
@@ -97,7 +97,7 @@ documentation:
   sources:
     public:
       enabled: true
-      repo: "https://github.com/pglevy/design-system-docs.git"
+      repo: "https://github.com/appian-design/aurora.git"
 ```
 
 ### Dual Sources
@@ -107,11 +107,11 @@ documentation:
   sources:
     public:
       enabled: true
-      repo: "https://github.com/pglevy/design-system-docs.git"
+      repo: "https://github.com/appian-design/aurora.git"
       priority: 1
     internal:
       enabled: true
-      repo: "https://github.com/pglevy/design-system-docs-internal.git"
+      repo: "https://github.com/appian-design/aurora-internal.git"
       priority: 2
       auth_required: true
 ```

--- a/docs/DUAL-SOURCES.md
+++ b/docs/DUAL-SOURCES.md
@@ -41,7 +41,7 @@ documentation:
   sources:
     public:
       enabled: true
-      repo: "https://github.com/pglevy/design-system-docs.git"
+      repo: "https://github.com/appian-design/aurora.git"
       priority: 1
 ```
 
@@ -66,11 +66,11 @@ documentation:
   sources:
     public:
       enabled: true
-      repo: "https://github.com/pglevy/design-system-docs.git"
+      repo: "https://github.com/appian-design/aurora.git"
       priority: 1
     internal:
       enabled: true
-      repo: "https://github.com/pglevy/design-system-docs-internal.git"
+      repo: "https://github.com/appian-design/aurora-internal.git"
       priority: 2
       auth_required: true
       submodule_path: "design-system-docs"

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ const DEFAULT_CONFIG: Config = {
       public: {
         enabled: true,
         path: "./docs-public",
-        repo: "https://github.com/pglevy/design-system-docs.git",
+        repo: "https://github.com/appian-design/aurora.git",
         branch: "main",
         priority: 1,
         auth_required: false,


### PR DESCRIPTION
Change references for repos and sites to new location

NOTE: Some of these changes assume we're moving the internal site to aurora-internal on GitHub (not GitLab), which is probably a safe assumption for now.
