### PR TITLE
Fix GitHub API authentication and URL parsing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc && chmod 755 build/index.js",
+    "build:clean": "rm -rf build && npm run build",
     "test": "npm run build && node test.js",
     "test:config": "npm run build && node build/config.test.js",
     "test:source-manager": "npm run build && node build/source-manager.test.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -210,8 +210,15 @@ function applyEnvironmentOverrides(config: Config): Config {
   // Configure public repository from environment variables
   const githubOwner = loadEnvVariable("GITHUB_OWNER");
   const githubRepo = loadEnvVariable("GITHUB_REPO");
+  const githubToken = loadEnvVariable("GITHUB_TOKEN");
+  
   if (githubOwner && githubRepo) {
     config.documentation.sources.public.repo = `https://github.com/${githubOwner}/${githubRepo}.git`;
+  }
+  
+  // Enable authentication for public source if token is available (to avoid rate limits)
+  if (githubToken) {
+    config.documentation.sources.public.auth_required = true;
   }
 
   // Enable internal docs if environment variable is set

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,8 +382,6 @@ server.tool(
       response += `\n\n---\n\n## SAIL Coding Guidance\n\n${sailGuidance}`;
     }
     
-    console.error(`[DEBUG] Final response size: ${response.length} characters for ${component.title} from ${sourcedContent.source}`);
-    
     return {
       content: [
         {

--- a/src/source-manager.ts
+++ b/src/source-manager.ts
@@ -137,7 +137,7 @@ export class SourceManager {
     try {
       // For now, use GitHub API (in future this could support local files, git clones, etc.)
       const repoUrl = source.repo;
-      const match = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+)(?:\.git)?/);
+      const match = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/);
       
       if (!match) {
         throw new Error(`Invalid GitHub repository URL: ${repoUrl}`);
@@ -153,7 +153,7 @@ export class SourceManager {
 
       const token = getAuthToken(source);
       if (token) {
-        headers['Authorization'] = `token ${token}`;
+        headers['Authorization'] = `Bearer ${token}`;
       }
 
       const response = await fetch(url, { headers });


### PR DESCRIPTION
## Problem
The `get-component-details` tool was failing after recent repository migration and documentation structure changes. The issues were:

1. **GitHub API Rate Limiting**: Public source was configured without authentication, causing 403 errors due to rate limits
2. **URL Parsing**: Regex pattern wasn't properly handling `.git` suffix in repository URLs

## Solution
- Enable authentication for public source when GitHub token is available
- Fix regex pattern to properly strip `.git` suffix from repository URLs  
- Update to Bearer token authentication format
- Clean up debug logging

## Testing
- Verified `get-component-details` now successfully fetches and returns component documentation
- Confirmed authentication is working and rate limits are avoided
- All existing functionality preserved

## Files Changed
- `src/config.ts`: Enable auth for public source when token available
- `src/source-manager.ts`: Fix URL parsing regex and update auth format
- `src/index.ts`: Remove debug logging
- `package.json`: Existing changes preserved